### PR TITLE
fix indentation for langfiles

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -67,12 +67,11 @@ function timestampComment() {
 }
 
 const WRITE_SERIIALIZER = {
-  json: function (bundle) {
+  json(bundle) {
     return JSON.stringify(bundle, null, 2);
   },
-  module: function (bundle) {
-    const bundleData = JSON.stringify(bundle);
-    return `${ timestampComment() }\nmodule.exports = ${ bundleData };`;
+  module(bundle) {
+    return `${ timestampComment() }\n\nmodule.exports = ${JSON.stringify(bundle, null, 2)};`;
   },
 };
 


### PR DESCRIPTION
previously, langfiles would only be on one line.
they now have have standard pojo format and indentation,
which will in turn make diffs much more readable

will read like so:
```javascript
/** auto-generated on 2017-02-24T01:10:59.273Z */

module.exports = {
  "test": "test"
};
```